### PR TITLE
example of how to load NIRSx data from the mNE tutorial

### DIFF
--- a/loadExampleData.py
+++ b/loadExampleData.py
@@ -1,0 +1,21 @@
+import pandas as pd 
+import matplotlib.pyplot as plt
+import numpy as np 
+import os
+from itertools import compress
+import mne
+
+# Example from https://mne.tools/dev/auto_tutorials/preprocessing/plot_70_fnirs_processing.html
+
+fnirs_data_folder = mne.datasets.fnirs_motor.data_path()
+fnirs_raw_dir = os.path.join(fnirs_data_folder, 'Participant-1')
+raw_intensity = mne.io.read_raw_nirx(fnirs_raw_dir, verbose=True).load_data()
+
+picks = mne.pick_types(raw_intensity.info, meg=False, fnirs=True)
+dists = mne.preprocessing.nirs.source_detector_distances(
+	raw_intensity.info, picks=picks)
+raw_intensity.pick(picks[dists > 0.01])
+raw_intensity.plot(n_channels=len(raw_intensity.ch_names), 
+					duration=500, show_scrollbars=False)
+
+plt.show()

--- a/loadExampleData.py
+++ b/loadExampleData.py
@@ -9,12 +9,21 @@ import mne
 
 fnirs_data_folder = mne.datasets.fnirs_motor.data_path()
 fnirs_raw_dir = os.path.join(fnirs_data_folder, 'Participant-1')
+
+# MNE raw object - https://mne.tools/stable/generated/mne.io.Raw.html
 raw_intensity = mne.io.read_raw_nirx(fnirs_raw_dir, verbose=True).load_data()
+print("Raw imported data file: ", raw_intensity)
 
 picks = mne.pick_types(raw_intensity.info, meg=False, fnirs=True)
+print("Channels to pull out: ", picks)
+
 dists = mne.preprocessing.nirs.source_detector_distances(
 	raw_intensity.info, picks=picks)
+print("Channel distances: ", dists)
+
 raw_intensity.pick(picks[dists > 0.01])
+print("Long enough channels: ", raw_intensity)
+
 raw_intensity.plot(n_channels=len(raw_intensity.ch_names), 
 					duration=500, show_scrollbars=False)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ kiwisolver==1.2.0
 MarkupSafe==1.1.1
 matplotlib==3.2.1
 mistune==0.8.4
+mne==0.20.0
 nbconvert==5.6.1
 nbformat==5.0.5
 notebook==6.0.3
@@ -42,6 +43,7 @@ pytz==2019.3
 pyzmq==19.0.0
 qtconsole==4.7.2
 QtPy==1.9.0
+scipy==1.4.1
 Send2Trash==1.5.0
 six==1.14.0
 terminado==0.8.3


### PR DESCRIPTION
I made another script file you can run from inside the virtual environment called loadExampleData.py using an example from an mne tutorial on loading the NIRx data, it loads in and plots their example data.

@kuziekj @ssheldo 
You may also want a good text editor to work in, I use sublime, and I make it so I can open it from the terminal by typing subl filename.txt, or subl . to open the current directory. 